### PR TITLE
Fixconnect

### DIFF
--- a/tutorials/SimilaritySearch/memorydb-vss/mmlib.py
+++ b/tutorials/SimilaritySearch/memorydb-vss/mmlib.py
@@ -22,9 +22,12 @@ model = SentenceTransformer('sentence-transformers/all-distilroberta-v1')
 
 # Initialize Redis client
 def initialize_redis():
-    client = Redis(host=MEMORYDB_CLUSTER, 
-           port=6379,ssl=True, decode_responses=True, ssl_cert_reqs="none")
-    
+    client = redis.Redis(
+        host=MEMORYDB_CLUSTER,
+        port=6379, 
+        decode_responses=True, 
+        ssl=True, 
+        ssl_cert_reqs="none")
     try:
         client.ping()
         print("Connection to MemoryDB successful")

--- a/tutorials/SimilaritySearch/requirements.txt
+++ b/tutorials/SimilaritySearch/requirements.txt
@@ -1,4 +1,4 @@
-faiss-cpu==1.8.0
+#faiss-cpu==1.8.0
 transformers==4.39.3
 Pillow==10.3.0
 pypdf==4.2.0


### PR DESCRIPTION
*Issue #, Connectivity issue with MemoryDB*

*Updated the connection string to use RedisCluster.client = redis.Redis(
        host=MEMORYDB_CLUSTER,
        port=6379, 
        decode_responses=True, 
        ssl=True, 
        ssl_cert_reqs="none")  :*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
