### PR TITLE
Update requirements.txt to include redis-py-cluster

### DIFF
--- a/tutorials/cross-region-memorydb-vector-search/requirements.txt
+++ b/tutorials/cross-region-memorydb-vector-search/requirements.txt
@@ -1,5 +1,5 @@
 redis==5.0.1
-redis-cluster==2.1.3
+redis-py-cluster==2.1.3
 boto3==1.34.0
 botocore==1.34.0
 urllib3==1.26.18


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix: Replace unregistered redis-cluster package with redis-py-cluster

redis-cluster is not registered on PyPI. This creates a dependency 
confusion risk where a malicious actor could register the package 
and serve harmful code to anyone following the tutorial.

Replacing with redis-py-cluster (the correct registered package) which includes built-in cluster support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
